### PR TITLE
Add a whois endpoint

### DIFF
--- a/docs/endpoints/Get Identity.md
+++ b/docs/endpoints/Get Identity.md
@@ -22,17 +22,22 @@ the following response if everything went alright, otherwise an error may occur.
 
 ### Response Body
 
-#### Invalid Player - Response
-There was a problem with finding the identity of the player.
+#### No Data - Response
+The player does not exist
 
 | Attribute   | Type    | Description                                      |
 |-------------|---------|--------------------------------------------------|
 | player_type | string  | Possible types are described below               |
+ - "not_found": This player could not be found
+ - "outdated_spec": special state indicating that the client must be updated
+in order to account for a change that is not backwards compatible.
 
- - "not_found": This player could not be found.
- - "pending_auth": An auth code has been generated for the player,
-however the code has not been submitted in Discord.
+#### Unlinked Player - Response
 
+| Attribute   | Type    | Description                                      |
+|-------------|---------|--------------------------------------------------|
+| player_type | string  | Will be "pending_auth" - An auth code has been generated for the player, however the code has not been submitted in Discord. |
+| player_id   | string  | The Minecraft UUID for the player                |
 
 #### Valid Player - Response
 The player exists, here is the linked account
@@ -40,6 +45,7 @@ The player exists, here is the linked account
 | Attribute   | Type    | Description                                      |
 |-------------|---------|--------------------------------------------------|
 | snowflake   | string  | The Discord snowflake (id) of the player         |
+| player_id   | string  | The Minecraft UUID for the player                |
 | player_type | string  | Possible types are described below               |
  - "player": This is a regular player who is allowed on the server.
  - "alt": This is an alt account of a staff member

--- a/docs/endpoints/Get Identity.md
+++ b/docs/endpoints/Get Identity.md
@@ -37,8 +37,6 @@ however the code has not been submitted in Discord.
 #### Valid Player - Response
 The player exists, here is the linked account
 
-**Note: This is not finalised! The user#1234 data might be added following discussion on how the data should be obtained**
-
 | Attribute   | Type    | Description                                      |
 |-------------|---------|--------------------------------------------------|
 | snowflake   | string  | The Discord snowflake (id) of the player         |

--- a/docs/endpoints/Get Identity.md
+++ b/docs/endpoints/Get Identity.md
@@ -1,10 +1,10 @@
 # Player Verification
-This is where the client can retrieve the Discord identity of a player based on their Minecraft UUID without initiating an auth code check.
+This is where the client can retrieve the Discord identity of a player based on their Minecraft Name without initiating an auth code check.
 This can be useful for debugging the current state of the user.
 
-## GET /player/{Player UUID}
+## GET /player/{Player Name}
 Possible Errors:
- * [Missing Player UUID Attribute](#Missing-Player-UUID-Attribute)
+ * [Missing Player Name Attribute](#Missing-Player-Name-Attribute)
 
 This endpoint finds the discord identity of a player.
 
@@ -14,9 +14,9 @@ Required Headers:
 
 | Attribute   | Type   | Description             |
 |-------------|--------|-------------------------|
-| Player UUID | string | The Minecraft player ID |
+| Player Name | string | The Minecraft player name |
 
-The `player UUID` is the Minecraft player UUID stripped of all the dashes. The server will provide
+The `Player Name` is the Minecraft player Name stripped of all the dashes. The server will provide
 the following response if everything went alright, otherwise an error may occur.
 
 
@@ -47,7 +47,7 @@ The player exists, here is the linked account
 
 ## Errors
 
-### Missing Player UUID Attribute
+### Missing Player Name Attribute
 ```json
 {
   "errcode": "NO_PLAYER_ID",

--- a/docs/endpoints/Get Identity.md
+++ b/docs/endpoints/Get Identity.md
@@ -1,0 +1,58 @@
+# Player Verification
+This is where the client can retrieve the Discord identity of a player based on their Minecraft UUID without initiating an auth code check.
+This can be useful for debugging the current state of the user.
+
+## GET /player/{Player UUID}
+Possible Errors:
+ * [Missing Player UUID Attribute](#Missing-Player-UUID-Attribute)
+
+This endpoint finds the discord identity of a player.
+
+Required Headers:
+ 1. Content-Type: `application/json`
+ 2. Authorization: `<webserver token>` 
+
+| Attribute   | Type   | Description             |
+|-------------|--------|-------------------------|
+| Player UUID | string | The Minecraft player ID |
+
+The `player UUID` is the Minecraft player UUID stripped of all the dashes. The server will provide
+the following response if everything went alright, otherwise an error may occur.
+
+
+### Response Body
+
+#### Invalid Player - Response
+There was a problem with finding the identity of the player.
+
+| Attribute   | Type    | Description                                      |
+|-------------|---------|--------------------------------------------------|
+| player_type | string  | Possible types are described below               |
+
+ - "not_found": This player could not be found.
+ - "pending_auth": An auth code has been generated for the player,
+however the code has not been submitted in Discord.
+
+
+#### Valid Player - Response
+The player exists, here is the linked account
+
+**Note: This is not finalised! The user#1234 data might be added following discussion on how the data should be obtained**
+
+| Attribute   | Type    | Description                                      |
+|-------------|---------|--------------------------------------------------|
+| snowflake   | string  | The Discord snowflake (id) of the player         |
+| player_type | string  | Possible types are described below               |
+ - "player": This is a regular player who is allowed on the server.
+ - "alt": This is an alt account of a staff member
+ - "banned": This person is banned from using the bot and auth server.
+
+## Errors
+
+### Missing Player UUID Attribute
+```json
+{
+  "errcode": "NO_PLAYER_ID",
+  "message": "There wasn't a player ID provided"
+}
+```

--- a/docs/endpoints/Get Identity.md
+++ b/docs/endpoints/Get Identity.md
@@ -36,8 +36,8 @@ in order to account for a change that is not backwards compatible.
 
 | Attribute   | Type    | Description                                      |
 |-------------|---------|--------------------------------------------------|
-| player_type | string  | Will be "pending_auth" - An auth code has been generated for the player, however the code has not been submitted in Discord. |
 | player_id   | string  | The Minecraft UUID for the player                |
+| player_type | string  | Will be "pending_auth" - An auth code has been generated for the player, however the code has not been submitted in Discord. |
 
 #### Valid Player - Response
 The player exists, here is the linked account


### PR DESCRIPTION
This pull request is intended for a server-side implementation of necessary data for a whois command within the client.

Current draft of endpoint documentation:

# Player Verification
This is where the client can retrieve the Discord identity of a player based on their Minecraft Name without initiating an auth code check.
This can be useful for debugging the current state of the user.

## GET /player/{Player Name}
Possible Errors:
 * [Missing Player Name Attribute](#Missing-Player-Name-Attribute)

This endpoint finds the discord identity of a player.

Required Headers:
 1. Content-Type: `application/json`
 2. Authorization: `<webserver token>` 

| Attribute   | Type   | Description             |
|-------------|--------|-------------------------|
| Player Name | string | The Minecraft player name |

The `Player Name` is the Minecraft player Name stripped of all the dashes. The server will provide
the following response if everything went alright, otherwise an error may occur.


### Response Body

#### No Data - Response
The player does not exist

| Attribute   | Type    | Description                                      |
|-------------|---------|--------------------------------------------------|
| player_type | string  | Possible types are described below               |
 - "not_found": This player could not be found
 - "outdated_spec": special state indicating that the client must be updated
in order to account for a change that is not backwards compatible.

#### Unlinked Player - Response

| Attribute   | Type    | Description                                      |
|-------------|---------|--------------------------------------------------|
| player_id   | string  | The Minecraft UUID for the player                |
| player_type | string  | Will be "pending_auth" - An auth code has been generated for the player, however the code has not been submitted in Discord. |

#### Valid Player - Response
The player exists, here is the linked account

| Attribute   | Type    | Description                                      |
|-------------|---------|--------------------------------------------------|
| snowflake   | string  | The Discord snowflake (id) of the player         |
| player_id   | string  | The Minecraft UUID for the player                |
| player_type | string  | Possible types are described below               |
 - "player": This is a regular player who is allowed on the server.
 - "alt": This is an alt account of a staff member
 - "banned": This person is banned from using the bot and auth server.

## Errors

### Missing Player Name Attribute
```json
{
  "errcode": "NO_PLAYER_ID",
  "message": "There wasn't a player ID provided"
}
```
