### PR TITLE
Added Small API Support

### DIFF
--- a/docs/endpoints/API.md
+++ b/docs/endpoints/API.md
@@ -1,0 +1,27 @@
+# API Endpoints
+
+
+## GET /api/resolve/{id}
+Possible Errors:
+ * [Missing ID](#Missing-ID-Attribute)
+ * [Invalid ID](#Invalid-ID)
+
+This endpoint will get the Minecraft player UUID associated with a Discord ID given or vice-versa. If an ID isn't provided then "Missing ID" error is given, if the ID provided isn't found then "Invalid ID" error is given.
+
+## Errors
+
+### Missing ID Attribute
+```json
+{
+    "errcode": "MISSING_ID",
+    "message": "A resolvable ID is missing in the URL path."
+}
+```
+
+### Invalid ID
+```json
+{
+    "errcode": "INVALID_ID",
+    "message": "The ID provided isn't in the database or is invalid."
+}
+```

--- a/internal/common/responses.go
+++ b/internal/common/responses.go
@@ -67,3 +67,8 @@ type DelAltResponse struct {
 	// whether or not it was successfully removed
 	IsRemoved bool `json:"is_deleted"`
 }
+
+// ResolveIDResponse comes from the /api/resolve/{id} endpoint
+type ResolveIDResponse struct {
+	Resolved string `json:"resolved_id"`
+}

--- a/internal/webserver/routes/api.go
+++ b/internal/webserver/routes/api.go
@@ -1,0 +1,43 @@
+package routes
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/dylhack/mcauth/internal/common"
+	"github.com/gorilla/mux"
+)
+
+func (server *Server) resolveID(res http.ResponseWriter, req *http.Request) {
+	store := &server.Store.Links
+	args := mux.Vars(req)
+	id, isOK := args["id"]
+
+	if !isOK {
+		MissingIDError(res)
+		return
+	}
+
+	id = strings.ReplaceAll(id, "-", "")
+	var resolved string
+	var err error
+
+	// UUIDv4's will always be 32 characters
+	if len(id) == 32 {
+		resolved, err = store.GetDiscordID(id)
+	} else { // else it's a Discord Snowflake ID
+		resolved, err = store.GetPlayerID(id)
+	}
+
+	if err != nil {
+		InvalidIDError(res)
+		return
+	}
+
+	Ship(
+		res,
+		common.ResolveIDResponse{
+			Resolved: resolved,
+		},
+	)
+}

--- a/internal/webserver/routes/errors.go
+++ b/internal/webserver/routes/errors.go
@@ -68,6 +68,26 @@ func AltAlreadyExistsError(res http.ResponseWriter) {
 	ShipError(res, altAlreadyExists)
 }
 
+// MissingIDError occurs when an ID isn't provided in the /api/resolve endpoint
+func MissingIDError(res http.ResponseWriter) {
+	missingID := common.ErrorResponse{
+		ErrorCode: "MISSING_ID",
+		Message:   "A resolvable ID is missing in the URL path.",
+	}
+
+	ShipError(res, missingID)
+}
+
+// InvalidIDError occurs when someone tries to resolve an unresolvable ID
+func InvalidIDError(res http.ResponseWriter) {
+	invalidID := common.ErrorResponse{
+		ErrorCode: "INVALID_ID",
+		Message:   "The ID provided isn't in the database or is invalid.",
+	}
+
+	ShipError(res, invalidID)
+}
+
 // ShipError prepares and sends an error response given.
 func ShipError(res http.ResponseWriter, response interface{}) {
 	res.Header().Set("Content-Type", "application/json")

--- a/internal/webserver/routes/routes.go
+++ b/internal/webserver/routes/routes.go
@@ -47,6 +47,10 @@ func StartAllRoutes(bot *bot.Bot, store *db.Store, config *common.WebServerConfi
 	// DELETE /alt/{alt name}
 	router.HandleFunc("/alts/{alt_name}", server.deleteAlt).
 		Methods("DELETE")
+
+	// GET /api/resolve/{Discord ID or Minecraft UUIDv4}
+	router.HandleFunc("/api/resolve/{id}", server.resolveID).
+		Methods("GET")
 }
 
 // Ship sends a response body.


### PR DESCRIPTION
MCAuth now has an /api endpoint, currently it still requires the third-party clients to utilize the token that the Minecraft server does, in the future this will be replaced with JWT.